### PR TITLE
feat/85 : Comment Entity active 필드 및 ip 필드 추가

### DIFF
--- a/festival/src/main/java/likelion/festival/controller/BoothController.java
+++ b/festival/src/main/java/likelion/festival/controller/BoothController.java
@@ -101,8 +101,8 @@ public class BoothController {
     }
 
     @PostMapping("{id}/comments")
-    public CommentResponseDto createComment(@PathVariable Long id, @RequestBody CommentRequestDto commentRequestDto){
-        return commentService.create(id, commentRequestDto);
+    public CommentResponseDto createComment(@PathVariable Long id, @RequestBody CommentRequestDto commentRequestDto, HttpServletRequest request){
+        return commentService.create(id, commentRequestDto, request);
     }
 
     @GetMapping("{id}/comments")

--- a/festival/src/main/java/likelion/festival/dto/CommentRequestDto.java
+++ b/festival/src/main/java/likelion/festival/dto/CommentRequestDto.java
@@ -16,6 +16,10 @@ public class CommentRequestDto {
 
     private String password;
 
+    private String ip;
+
+    private Boolean active;
+
     private String content;
 
     private Booth booth;

--- a/festival/src/main/java/likelion/festival/dto/CommentResponseDto.java
+++ b/festival/src/main/java/likelion/festival/dto/CommentResponseDto.java
@@ -14,7 +14,6 @@ public class CommentResponseDto {
 
     private String writer;
 
-
     private String content;
 
     private LocalDateTime createdDateTime;

--- a/festival/src/main/java/likelion/festival/entity/Comment.java
+++ b/festival/src/main/java/likelion/festival/entity/Comment.java
@@ -30,8 +30,22 @@ public class Comment extends BaseEntity {
     private String content;
 
     @NotNull
+    private String ip;
+
+    @NotNull
+    private Boolean active;
+
+    @NotNull
     @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "booth_id")
     private Booth booth;
+
+    public void setIp(String ip){
+        this.ip = ip;
+    }
+
+    public void setActivte(Boolean active){
+        this.active = active;
+    }
 }

--- a/festival/src/main/java/likelion/festival/repository/CommentRepository.java
+++ b/festival/src/main/java/likelion/festival/repository/CommentRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByBooth_IdOrderByCreatedDateTimeDesc(Long id);
+    List<Comment> findByBooth_IdAndActiveOrderByCreatedDateTimeDesc(Long id,Boolean active);
 }


### PR DESCRIPTION
1. Comment Entity에 String ip 필드 Boolean active 필드 추가했습니다.
2. Comment 생성시에 ip 받아와서 저장해놓고, active 필드는 자동으로 Boolean.TRUE 설정됩니다.
3. Comment 삭제시엔 레포에서 삭제되는 것이 아니라 active 필드가 Boolean.FALSE로 변경됩니다.
4. 전체 Comment 가져올 때 active = Boolean.TRUE인 엔티티들만 가져오도록 처리해놨습니다. FE에서 로직 안바꿔도될듯??